### PR TITLE
Use the home_assistant user for most tasks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ home-assistant service wit git based configuration
           engine: git
           address: '${_param:home_assistant_config_repository}'
           branch: ${_param:home_assistant_config_revision}
+          identity: /path/to/optional/ssh/identity/file
 
 
 References


### PR DESCRIPTION
This updates the formula to use the home_assistant user for tasks like
cloning the git repo and making the virtual environment. This allows
home assistant to perform some tasks it otherwise can't do due to
permission issues, like installing needed python libraries at runtime.

This also adds the ability to specify the ssh identity used for cloning
the configuration git repo.

I also removed the home_assistant_config_dir state since the
home_assistant_dir state made it redundant.

Signed-off-by: M. David Bennett <mdavidbennett@syntheticworks.com>